### PR TITLE
Add Support for Reading Replys [WIP]

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,19 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": ".NET MonoGame DesktopGL",
+            "type": "coreclr",
+            "request": "launch",
+            "preLaunchTask": "Build",
+            "program": "${workspaceFolder}/JdwpDotNet/bin/Debug/net8.0/JdwpDotNet.dll",
+            "args": [],
+            "cwd": "${workspaceFolder}",
+            "stopAtEntry": false,
+            "console": "internalConsole"
+        },
+    ]
+}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,7 +5,7 @@
     "version": "0.2.0",
     "configurations": [
         {
-            "name": ".NET MonoGame DesktopGL",
+            "name": "Run",
             "type": "coreclr",
             "request": "launch",
             "preLaunchTask": "Build",

--- a/JdwpDotNet/JdwpDotNet.csproj
+++ b/JdwpDotNet/JdwpDotNet.csproj
@@ -2,9 +2,8 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/JdwpDotNetLib/JdwpClient.cs
+++ b/JdwpDotNetLib/JdwpClient.cs
@@ -62,6 +62,10 @@ public class JdwpClient
 
 			foreach (var replyPacket in replyPackets)
 				Debug.WriteLine($"RX Reply: {replyPacket.Id}, Data len: {replyPacket.Data.Length}");
+
+			// Keep the Connection for 1300 milliseconds, otherwise the Android OS ignores the connection!
+			//https://github.com/aosp-mirror/platform_frameworks_base/blob/main/core/java/android/os/Debug.java#L101C50-L101C54
+			await Task.Delay (1300);
 		}
 		else
 		{

--- a/JdwpDotNetLib/JdwpDotNetLib.csproj
+++ b/JdwpDotNetLib/JdwpDotNetLib.csproj
@@ -1,9 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
   </PropertyGroup>
 
 </Project>

--- a/JdwpDotNetLib/ReplyPacket.cs
+++ b/JdwpDotNetLib/ReplyPacket.cs
@@ -1,4 +1,5 @@
 ﻿using System.Buffers.Binary;
+using System.Text;
 using static System.Runtime.InteropServices.JavaScript.JSType;
 using System.Reflection.PortableExecutable;
 
@@ -6,7 +7,7 @@ namespace JdwpDotNet;
 
 public class ReplyPacket : Packet
 {
-	public void FromMemory(ReadOnlyMemory<byte> header, ReadOnlyMemory<byte> data)
+	public virtual void FromMemory(ReadOnlyMemory<byte> header, ReadOnlyMemory<byte> data)
 	{
 		Id = BinaryPrimitives.ReadInt32BigEndian(header[4..7].Span);
 		Flags = header.Span[8];
@@ -48,5 +49,159 @@ public class ReplyPacket : Packet
 			Data.Span.CopyTo(headerSpan[11..].Span);
 
 		return headerSpan;
+	}
+
+	internal class EventSetCommandPacket : CommandPacket 
+	{
+		public EventSetCommandPacket(byte eventKind, byte suspendPolicy)
+		{
+			CommandSet = 15;
+			Command = 1;
+			EventKind = eventKind;
+			SuspendPolicy = suspendPolicy;
+			Memory<byte> data  = new byte[2];
+			int index = 0;
+			data.Span[index++] = EventKind;
+			data.Span[index++] = SuspendPolicy;
+			Data = data;
+		}
+
+		public byte EventKind = 0;
+		public byte SuspendPolicy = 0;
+	}
+
+	internal class EventSetCommandIgnoreThrowablePacket : EventSetCommandPacket 
+	{
+		public EventSetCommandIgnoreThrowablePacket(byte eventKind, byte suspendPolicy) : base (eventKind, suspendPolicy)
+		{
+			CommandSet = 15;
+			Command = 1;
+			EventKind = eventKind;
+			SuspendPolicy = suspendPolicy;
+			Memory<byte> data  = new byte[35];
+			int index = 0;
+			data.Span[index++] = EventKind;
+			data.Span[index++] = SuspendPolicy;
+			BinaryPrimitives.WriteInt32BigEndian (data.Slice (index).Span, 2);
+			index += 4;
+			data.Span[index++] = 5;
+			
+			var bytes = Encoding.UTF8.GetBytes ("java.lang.Throwable");
+			BinaryPrimitives.WriteInt32BigEndian (data.Slice (index).Span, bytes.Length);
+			index += 4;
+			foreach (var b in bytes) {
+				data.Span[index++] = b;
+			}
+			data.Span[index++] = 1;
+			BinaryPrimitives.WriteInt32BigEndian (data.Slice (index).Span, 1);
+			Data = data;
+		}
+
+		public byte EventKind = 8;
+		public byte SuspendPolicy = 2;
+	}
+
+	internal class EventClearCommandPacket : CommandPacket 
+	{
+		public EventClearCommandPacket(int eventKind, int requestId)
+		{
+			CommandSet = 15;
+			Command = 2;
+			Memory<byte> data  = new byte[8];
+			BinaryPrimitives.WriteInt32BigEndian (data.Slice (0).Span, eventKind);
+			BinaryPrimitives.WriteInt32BigEndian (data.Slice (4).Span, requestId);
+			Data = data;
+		}
+
+		public byte EventKind = 8;
+		public byte SuspendPolicy = 2;
+		// public Modifier[] Modifiers = new Modifier[0];
+
+		// public struct Modifier
+		// {
+		// 	public byte ModifierKind = 0;
+		// }
+
+	}
+
+	internal class ThreadStatusCommandPacket : CommandPacket
+	{
+		public ThreadStatusCommandPacket(long threadId)
+		{
+			CommandSet = 11;
+			Command = 4;
+			ThreadId = threadId;
+			Memory<byte> data  = new byte[8];
+			BinaryPrimitives.WriteInt64BigEndian (data.Slice(0).Span, threadId);
+			Data = data;
+		}
+
+		public long ThreadId {get;set;}
+	}
+
+	internal class AllThreadsCommandPacket : CommandPacket
+	{
+		public AllThreadsCommandPacket()
+		{
+			CommandSet = 1;
+			Command = 4;
+		}
+	}
+
+	internal class AllThreadReply : ReplyPacket
+	{
+		public long[] ThreadIds {get; set; }
+		public AllThreadReply()
+		{
+		}
+
+		public override void FromMemory (ReadOnlyMemory<byte> header, ReadOnlyMemory<byte> data)
+		{
+			base.FromMemory (header, data);
+			// process the data.
+			var count = BinaryPrimitives.ReadInt32BigEndian(data.Slice(0, 4).Span);
+			Console.WriteLine ($"DEBUG! got {count} Threads.");
+			var buffer = data.Slice (4);
+			ThreadIds = new long[count];
+			for (int i=0; i < count; i++) {
+				ThreadIds[i] =  BinaryPrimitives.ReadInt64BigEndian (buffer.Slice (i*8, 8).Span);
+				Console.WriteLine ($"DEBUG! ThreadIds[{i}] = {ThreadIds[i]}.");
+			}
+		}
+	}
+
+	internal class ThreadStatusReply : ReplyPacket
+	{
+		public ThreadStatusReply()
+		{
+		}
+
+		public override void FromMemory (ReadOnlyMemory<byte> header, ReadOnlyMemory<byte> data)
+		{
+			base.FromMemory (header, data);
+			// process the data.
+			var threadStatus = BinaryPrimitives.ReadInt32BigEndian(data.Slice(0, 4).Span);
+			var suspendStatus = BinaryPrimitives.ReadInt32BigEndian(data.Slice(4, 4).Span);
+			Console.WriteLine ($"\t Status:{threadStatus} Suspend:{suspendStatus}.");
+			
+		}
+	}
+
+	internal class EventSetReply : ReplyPacket
+	{
+		public EventSetReply()
+		{
+		}
+
+		public override void FromMemory (ReadOnlyMemory<byte> header, ReadOnlyMemory<byte> data)
+		{
+			base.FromMemory (header, data);
+			// process the data.
+			RequestId = BinaryPrimitives.ReadInt32BigEndian(data.Slice(0, 4).Span);
+			Console.WriteLine ($"\t RequestId:{RequestId}");
+			
+		}
+
+		public int RequestId;
 	}
 }

--- a/JdwpDotNetLib/ReplyPacket.cs
+++ b/JdwpDotNetLib/ReplyPacket.cs
@@ -6,7 +6,7 @@ namespace JdwpDotNet;
 
 public class ReplyPacket : Packet
 {
-	public ReplyPacket(ReadOnlyMemory<byte> header, ReadOnlyMemory<byte> data)
+	public void FromMemory(ReadOnlyMemory<byte> header, ReadOnlyMemory<byte> data)
 	{
 		Id = BinaryPrimitives.ReadInt32BigEndian(header[4..7].Span);
 		Flags = header.Span[8];


### PR DESCRIPTION
These change add the support for reading replies from the debugger.
It also documents a weird issue where if the client disconnects to early, it will not clear the debugger dialog on android. 
Looking at this code //https://github.com/aosp-mirror/platform_frameworks_base/blob/main/core/java/android/os/Debug.java#L101C50-L101C54, we have to wait for at least 1300ms before disconnecting. 
